### PR TITLE
Remove the wikipedia blocked statement

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -75,7 +75,7 @@ ReactDOM.işle(bileşen, document.idKullanarakElemanıGetir('kök'));
 
 ## Dış Bağlantılar
 
-Sayfada yer alan [MDN] veya [Wikipedia] gibi harici bağlantılar diğer bir makaleye yönelikse ve bu makalenin Türkçe dilinde kabul edilebilir kalitede bir sürümü varsa, bağlantıyı bu sürümünkiyle değiştirmeyi düşününüz. Ayrıca Wikipedia Türkiye'de uzun süredir yasaklı olduğu için, Wikipedia linklerini [MDN] veya [EksiSozluk] gibi tanınmış sitelerdeki versiyonları ile değiştirebilirsiniz.
+Sayfada yer alan [MDN] veya [Wikipedia] gibi harici bağlantılar diğer bir makaleye yönelikse ve bu makalenin Türkçe dilinde kabul edilebilir kalitede bir sürümü varsa, bağlantıyı bu sürümünkiyle değiştirmeyi düşününüz. 
 
 [MDN]: https://developer.mozilla.org/en-US/
 [Wikipedia]: https://en.wikipedia.org/wiki/Main_Page


### PR DESCRIPTION
Wikipedia is not blocked in Turkey since 15 January 2020.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
