### PR TITLE
Change Effect Hook Title

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -1,6 +1,6 @@
 ---
 id: hooks-state
-title: Using the Effect Hook
+title: Effect Hook'unu Kullanmak
 permalink: docs/hooks-effect.html
 next: hooks-rules.html
 prev: hooks-state.html

--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -116,7 +116,7 @@
       - id: hooks-state
         title: State Hook'unu Kullanmak
       - id: hooks-effect
-        title: Efekt Hook'unu Kullanmak
+        title: Effect Hook'unu Kullanmak
       - id: hooks-rules
         title: Hook Kuralları
       - id: hooks-custom


### PR DESCRIPTION
I think the effect hook translation in navigation is wrong. It should remain native just like the "state". Also, the title in the document had to be changed.
